### PR TITLE
If using JTDS, set portNumber and serverName separately

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -26,8 +26,8 @@
         username              (:username options)
         password              (:password options)
         database-name         (:database-name options)
-        server-name           (str (:server-name options))
-        port                  (str (:port options))
+        server-name           (:server-name options)
+        port                  (:port options)
         server-name-with-port (clojure.string/join [server-name ":" port])]
     (.setDataSourceClassName config datasource-class-name)
     (.setAutoCommit          config auto-commit)
@@ -40,7 +40,10 @@
     (.addDataSourceProperty  config "user"         username)
     (.addDataSourceProperty  config "password"     password)
     (.addDataSourceProperty  config "databaseName" database-name)
-    (.addDataSourceProperty  config "serverName"   server-name-with-port)
+    (if (= datasource-class-name "net.sourceforge.jtds.jdbcx.JtdsDataSource")
+      (do (.addDataSourceProperty config "serverName" server-name)
+          (.addDataSourceProperty config "portNumber" port))
+      (.addDataSourceProperty  config "serverName"  server-name-with-port))
     config))
 
 (defn datasource-from-config


### PR DESCRIPTION
When trying to get HikariCP working with SQL Server and the JTDS DataSource I ran into some trouble. I found that `portNumber` (note: not `port` in this case) needed to be set independently from `serverName`, otherwise it would throw an `UnknownHostException`.

I believe there is a similar issue when using the Microsoft SQL Server driver, but I did not take the time to figure it out as I only required JTDS.

Perhaps a better way to handle this would be to simply add something to the README to let people know that they may need to override DataSourceProperties depending on which driver they're using and reference the relevant documentation. In this case, a link to http://jtds.sourceforge.net/doc/net/sourceforge/jtds/jdbcx/JtdsDataSource.html with a small blurb explaining how `setFooBar` is related to the property `fooBar` on a driver level would have saved me some time.

Thanks,
Devin
