### PR TITLE
false is a valid datasource property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* fixed setting of datasource properties to false
+
 ## 1.1.0
 
 * updated `HikariCP` to `2.3.1`

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -76,7 +76,7 @@
 (defn- add-datasource-property
   ""
   [config property value]
-  (if value (.addDataSourceProperty config (mixed-name property) value)))
+  (when-not (nil? value) (.addDataSourceProperty config (mixed-name property) value)))
 
 (defn validate-options
   ""


### PR DESCRIPTION
We ran into an issue where we noticed a datasource property not propagating to the hikari connections.  Specifically the property we needed to set was `useLegacyDatetimeCode`, and we needed to set it to `false`.

The (if value ...) was essentially throwing away our false setting instead of setting the property to false.  Our workaround was to do this in our hikari datasource spec:

{:use-legacy-datetime-code "false"}

Perhaps this is the recommended solution, and if so, we can edit the README to reflect that.  Currently the README shows properties being set with boolean values (not strings).