### PR TITLE
add a general purpose way to alter Hikari config

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -93,8 +93,8 @@
   (let [config (HikariConfig.)
         options               (validate-options datasource-options)
         not-core-options      (apply dissoc options
-                                     (conj (keys ConfigurationOptions)
-                                           :username :password :pool-name :connection-test-query))
+                                     :username :password :pool-name :connection-test-query :configure
+                                     (keys ConfigurationOptions))
         {:keys [adapter
                 auto-commit
                 configure

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -97,6 +97,7 @@
                                            :username :password :pool-name :connection-test-query))
         {:keys [adapter
                 auto-commit
+                configure
                 connection-test-query
                 connection-timeout
                 validation-timeout
@@ -127,6 +128,8 @@
     (if password (.setPassword config password))
     (if pool-name (.setPoolName config pool-name))
     (if connection-test-query (.setConnectionTestQuery config connection-test-query))
+    (when configure
+      (configure config))
     ;; Set datasource-specific properties
     (doseq [[k v] not-core-options]
       (add-datasource-property config k v))


### PR DESCRIPTION
for options not currently supported by hikari-cp, for example setConnectionInitSql