### PR TITLE
fix: remove :leak-detection-threshold from datasource configs;

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -103,7 +103,8 @@
   (let [config (HikariConfig.)
         options               (validate-options datasource-options)
         not-core-options      (apply dissoc options
-                                     :username :password :pool-name :connection-test-query :configure
+                                     :username :password :pool-name :connection-test-query
+                                     :configure :leak-detection-threshold
                                      (keys ConfigurationOptions))
         {:keys [adapter
                 auto-commit


### PR DESCRIPTION
Hi,

i tried my changes for  `:leak-detection-threshold` in  a wild and it had little bug - it sent the :leak-detection-threshold option to PGdriver too. Here's my fix for it. 

ps: it helped me find a connection leak - my code didnt close DB connection when it transformed clojure vector to Postgres vector. And next time i will try my change before commiting. Sorry about it.