### PR TITLE
Correctly distinguish non core options

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -121,8 +121,9 @@
         options               (validate-options datasource-options)
         not-core-options      (apply dissoc options
                                      :username :password :pool-name :connection-test-query
-                                     :configure :leak-detection-threshold
-                                     (keys ConfigurationOptions))
+                                     :configure :leak-detection-threshold :adapter :jdbc-url
+                                     :driver-class-name
+                                     (keys BaseConfigurationOptions))
         {:keys [adapter
                 auto-commit
                 configure

--- a/test/hikari_cp/core_test.clj
+++ b/test/hikari_cp/core_test.clj
@@ -147,3 +147,8 @@
   (validate-options (assoc valid-options :leak-detection-threshold 1)))
 (expect IllegalArgumentException
   (validate-options (assoc valid-options :leak-detection-threshold 1999)))
+
+;; Ensure that core options aren't being set as datasource properties
+(expect #{"portNumber" "databaseName" "serverName"}
+  (set (keys (.getDataSourceProperties datasource-config-with-required-settings))))
+


### PR DESCRIPTION
This fixes a bug introduced in #23 where the non core options are no longer properly detected.