### PR TITLE
Call registerMbeans property only when it is specified

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -152,8 +152,6 @@
       (.setIdleTimeout         idle-timeout)
       (.setMaxLifetime         max-lifetime)
       (.setMinimumIdle         minimum-idle)
-      (.setMaximumPoolSize     maximum-pool-size)
-      (.setRegisterMbeans      register-mbeans)
       (.setMaximumPoolSize     maximum-pool-size))
     (if adapter
       (->> (get adapters-to-datasource-class-names adapter)
@@ -172,6 +170,8 @@
       (configure config))
     (when connection-init-sql
       (.setConnectionInitSql config connection-init-sql))
+    (when register-mbeans
+      (.setRegisterMbeans config register-mbeans))
     ;; Set datasource-specific properties
     (doseq [[k v] not-core-options]
       (add-datasource-property config k v))


### PR DESCRIPTION
With PostgreSql driver I get error below even when I set
:register-mbeans to false. It seems that you shouldn't call the
registerMbeans method at all with certain database drivers where
there is no support for that.

Caused by: java.lang.RuntimeException: Property registerMbeans does not exist on target class org.postgresql.ds.PGSimpleDataSource
        at com.zaxxer.hikari.util.PropertyElf.setProperty(PropertyElf.java:148)
        at com.zaxxer.hikari.util.PropertyElf.setTargetFromProperties(PropertyElf.java:62)
        at com.zaxxer.hikari.pool.PoolBase.initializeDataSource(PoolBase.java:293)
        at com.zaxxer.hikari.pool.PoolBase.<init>(PoolBase.java:84)
        at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:102)
        at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:71)
        at hikari_cp.core$make_datasource.invokeStatic(core.clj:182)
        at hikari_cp.core$make_datasource.invoke(core.clj:179)