### PR TITLE
added jdbc-url to be a required key for datasource

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -93,11 +93,13 @@
 
 (def DatasourceConfigurationOptions
   (assoc BaseConfigurationOptions
-    :datasource DataSource))
+         :jdbc-url s/Str
+         :datasource DataSource))
 
 (def DatasourceClassnameConfigurationOptions
   (assoc BaseConfigurationOptions
-    :datasource-classname s/Str))
+         :jdbc-url s/Str
+         :datasource-classname s/Str))
 
 ;(s/optional-key :driver-class-name)
 (def ConfigurationOptions (s/conditional


### PR DESCRIPTION
When configuring using a datasource, the `jdbc-url` needs to be supplies. I omitted it in the last pr.