### PR TITLE
fixed validation for datasource

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -93,12 +93,10 @@
 
 (def DatasourceConfigurationOptions
   (assoc BaseConfigurationOptions
-         :jdbc-url s/Str
          :datasource DataSource))
 
 (def DatasourceClassnameConfigurationOptions
   (assoc BaseConfigurationOptions
-         :jdbc-url s/Str
          :datasource-classname s/Str))
 
 ;(s/optional-key :driver-class-name)


### PR DESCRIPTION
HikariCP ignores `:jdbc-url` when using `:datasource-classname`, and `:jdbc-url` is not required for the `:datasource`, since it can provide its own connection.