### PR TITLE
Fixes #56: support Healthcheck from DropWizard Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## unreleased
 
-* updated  `HikariCP` to `2.6.0` 
+* updated  `HikariCP` to `2.6.0`
 * do not attempt to use :metric-registry as a datasource property
+* added support for dropwizard healthcheck functionality.
 
 ## 1.7.5
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You'll also need to add the JDBC driver needed for your database.
 | `:datasource`            | No       | None                   | This property allows you to directly set the instance of the DataSource to be wrapped by the pool.                                                                                                                                                                                                                                     |
 | `:datasource-classname`  | No       | None                   | This is the name of the DataSource class provided by the JDBC driver.                                                                                                                                                                                                                                                                  |
 | `:metric-registry`  | No      | None | This is an instance of a dropwizard metrics MetricsRegistry |
+| `:health-check-registry`  | No      | None | This is an instance of a dropwizard metrics HealthCheckRegistry |
 
 **¹** `:adapter` and `:jdbc-url` are mutually exclusive.
 

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                                   [mysql/mysql-connector-java "5.1.38"]
                                   [org.postgresql/postgresql  "9.3-1102-jdbc41"]
                                   [io.dropwizard.metrics/metrics-core "3.1.2"]
+                                  [io.dropwizard.metrics/metrics-healthchecks "3.1.2"]
 
                                   ; The Oracle driver is only accessible from maven.oracle.com
                                   ; which requires a userId and password

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -82,6 +82,7 @@
    :register-mbeans    s/Bool
    (s/optional-key :connection-init-sql) s/Str
    (s/optional-key :metric-registry) s/Any
+   (s/optional-key :health-check-registry) s/Any
    s/Keyword           s/Any})
 
 (def AdapterConfigurationOptions
@@ -143,7 +144,8 @@
         not-core-options      (apply dissoc options
                                      :username :password :pool-name :connection-test-query
                                      :configure :leak-detection-threshold :adapter :jdbc-url
-                                     :datasource-classname :driver-class-name :connection-init-sql :metric-registry
+                                     :datasource-classname :driver-class-name :connection-init-sql
+                                     :metric-registry :health-check-registry
                                      (keys BaseConfigurationOptions))
         {:keys [adapter
                 datasource
@@ -166,7 +168,8 @@
                 jdbc-url
                 driver-class-name
                 connection-init-sql
-                metric-registry]} options]
+                metric-registry
+                health-check-registry]} options]
     ;; Set pool-specific properties
     (doto config
       (.setAutoCommit          auto-commit)
@@ -190,6 +193,7 @@
     (when pool-name (.setPoolName config pool-name))
     (when connection-test-query (.setConnectionTestQuery config connection-test-query))
     (when metric-registry (.setMetricRegistry config metric-registry))
+    (when health-check-registry (.setHealthCheckRegistry config health-check-registry))
     (when leak-detection-threshold
       (.setLeakDetectionThreshold config ^Long leak-detection-threshold))
     (when configure

--- a/test/hikari_cp/core_test.clj
+++ b/test/hikari_cp/core_test.clj
@@ -2,7 +2,8 @@
   (:require [hikari-cp.core :refer :all])
   (:use expectations)
   (:import (com.zaxxer.hikari.pool HikariPool$PoolInitializationException)
-           (com.codahale.metrics MetricRegistry)))
+           (com.codahale.metrics MetricRegistry)
+           (com.codahale.metrics.health HealthCheckRegistry)))
 
 (def valid-options
   {:auto-commit              false
@@ -35,6 +36,9 @@
 (def metric-registry-options
   {:metric-registry (MetricRegistry.)})
 
+(def health-check-registry-options
+  {:health-check-registry (HealthCheckRegistry.)})
+
 (def datasource-config-with-required-settings
   (datasource-config (apply dissoc valid-options (keys default-datasource-options))))
 
@@ -54,6 +58,8 @@
                             {:adapter "mysql" :use-legacy-datetime-code false})))
 
 (def metric-registry-config (datasource-config (merge valid-options metric-registry-options)))
+
+(def health-check-registry-config (datasource-config (merge valid-options health-check-registry-options)))
 
 (expect false
         (get (.getDataSourceProperties mysql-datasouurce-config) "useLegacyDatetimeCode"))
@@ -87,6 +93,11 @@
         (.getMetricRegistry datasource-config-with-required-settings))
 (expect (:metric-registry metric-registry-options)
         (.getMetricRegistry metric-registry-config))
+
+(expect nil
+  (.getHealthCheckRegistry datasource-config-with-required-settings))
+(expect (:health-check-registry health-check-registry-options)
+  (.getHealthCheckRegistry health-check-registry-config))
 
 
 (expect false


### PR DESCRIPTION
Add support for DropWizard Metrics Healthcheck functionality.
Implemented in the same way as the Metrics base support.