### PR TITLE
Update Clojure to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* updated `Clojure` to `1.9.0`
+
 ## 1.8.3
 
 * allow custom `datasource-classname` along with `adapter`

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
         :url  "https://github.com/tomekw/hikari-cp"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.tobereplaced/lettercase "1.0.0"]
                  [com.zaxxer/HikariCP "2.7.4"]
                  [prismatic/schema "1.1.7"]]


### PR DESCRIPTION
I believe I will bump the project version to... `1.9.0` afterwards ;)

Next step: migrate from `schema` to `spec`.