### PR TITLE
Rename datasource-classname to datasource-class-name, fixes #46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 * updated `Clojure` to `1.9.0`
+* breaking change: rename `datasource-classname` to `datasource-class-name`
 
 ## 1.8.3
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You'll also need to add the JDBC driver needed for your database.
 | `:register-mbeans`          | No       | false                  | This property register mbeans which can be used in jmx to monitor hikari-cp.                                                                                                                                                                                                                                                           |
 | `:connection-init-sql`      | No       | None                   | This property sets a SQL statement that will be executed after every new connection creation before adding it to the pool.                                                                                                                                                                                                             |
 | `:datasource`               | No       | None                   | This property allows you to directly set the instance of the DataSource to be wrapped by the pool.                                                                                                                                                                                                                                     |
-| `:datasource-classname`     | No       | None                   | This is the name of the DataSource class provided by the JDBC driver.                                                                                                                                                                                                                                                                  |
+| `:datasource-class-name`    | No       | None                   | This is the name of the DataSource class provided by the JDBC driver.                                                                                                                                                                                                                                                                  |
 | `:metric-registry`          | No       | None                   | This is an instance of a Dropwizard metrics MetricsRegistry.                                                                                                                                                                                                                                                                           |
 | `:health-check-registry`    | No       | None                   | This is an instance of a Dropwizard metrics HealthCheckRegistry.                                                                                                                                                                                                                                                                       |
 
@@ -171,9 +171,9 @@ Custom translations of properties can be added by extending the
                          :adapter       "sybase"}) ; assumes jconn4.jar (com.sybase.jdbc4.jdbc.SybDataSource)
 
 ; if you're using jconn2.jar or jconn3.jar replace :adapter "sybase" with the following
-; :datasource-classname "com.sybase.jdbc3.jdbc.SybDataSource"
+; :datasource-class-name "com.sybase.jdbc3.jdbc.SybDataSource"
 ; or
-; :datasource-classname "com.sybase.jdbc2.jdbc.SybDataSource"
+; :datasource-class-name "com.sybase.jdbc2.jdbc.SybDataSource"
 
 (def datasource
   (make-datasource datasource-options))

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -100,12 +100,12 @@
 
 (def DatasourceClassnameConfigurationOptions
   (assoc BaseConfigurationOptions
-         :datasource-classname s/Str))
+         :datasource-class-name s/Str))
 
 ;(s/optional-key :driver-class-name)
 (def ConfigurationOptions (s/conditional
                              :datasource DatasourceConfigurationOptions
-                             :datasource-classname DatasourceClassnameConfigurationOptions
+                             :datasource-class-name DatasourceClassnameConfigurationOptions
                              :adapter AdapterConfigurationOptions
                              :jdbc-url JDBCUrlConfigurationOptions
                              :else AdapterConfigurationOptions))
@@ -144,12 +144,12 @@
         not-core-options      (apply dissoc options
                                      :username :password :pool-name :connection-test-query
                                      :configure :leak-detection-threshold :adapter :jdbc-url
-                                     :datasource-classname :driver-class-name :connection-init-sql
+                                     :datasource-class-name :driver-class-name :connection-init-sql
                                      :metric-registry :health-check-registry
                                      (keys BaseConfigurationOptions))
         {:keys [adapter
                 datasource
-                datasource-classname
+                datasource-class-name
                 auto-commit
                 configure
                 connection-test-query
@@ -185,7 +185,7 @@
       (->> (get adapters-to-datasource-class-names adapter)
            (.setDataSourceClassName config))
       (.setJdbcUrl config jdbc-url))
-    (when datasource-classname (.setDataSourceClassName config datasource-classname))
+    (when datasource-class-name (.setDataSourceClassName config datasource-class-name))
     ;; Set optional properties
     (when driver-class-name (.setDriverClassName config driver-class-name))
     (when username (.setUsername config username))

--- a/test/hikari_cp/core_test.clj
+++ b/test/hikari_cp/core_test.clj
@@ -31,7 +31,7 @@
    :jdbc-url          "jdbc:postgresql://localhost:5433/test"})
 
 (def alternate-valid-options2
-  {:datasource-classname "com.sybase.jdbc3.jdbc.SybDataSource"})
+  {:datasource-class-name "com.sybase.jdbc3.jdbc.SybDataSource"})
 
 (def metric-registry-options
   {:metric-registry (MetricRegistry.)})
@@ -56,7 +56,7 @@
 (def mysql-datasouurce-config
   (datasource-config (merge valid-options
                             {:adapter "mysql"
-                             :datasource-classname "com.mysql.cj.jdbc.MysqlDataSource"
+                             :datasource-class-name "com.mysql.cj.jdbc.MysqlDataSource"
                              :use-legacy-datetime-code false})))
 
 (def metric-registry-config (datasource-config (merge valid-options metric-registry-options)))


### PR DESCRIPTION
As we will bump major version anyway I don't plan to maintain two variants of the option name.

Fixes #46.