### PR TITLE
Throw when the obsolete API is used

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -106,6 +106,10 @@
 (def ConfigurationOptions (s/conditional
                              :datasource DatasourceConfigurationOptions
                              :datasource-class-name DatasourceClassnameConfigurationOptions
+                             ;; Make sure that if the user provides the class
+                             ;; name using the deprecated keyword we'll throw an
+                             ;; exception instead of silently failing.
+                             :datasource-classname DatasourceClassnameConfigurationOptions
                              :adapter AdapterConfigurationOptions
                              :jdbc-url JDBCUrlConfigurationOptions
                              :else AdapterConfigurationOptions))

--- a/test/hikari_cp/core_test.clj
+++ b/test/hikari_cp/core_test.clj
@@ -172,6 +172,8 @@
         (validate-options (merge valid-options {:maximum-pool-size 0})))
 (expect IllegalArgumentException
         (validate-options (merge valid-options {:adapter :foo})))
+(expect IllegalArgumentException
+        (validate-options (merge valid-options {:datasource-classname "adsf"})))
 (expect map?
         (validate-options (merge valid-options {:username nil})))
 (expect map?


### PR DESCRIPTION
In 5fa1a7fed677cb4beea1f3e8ed0bbc466e8d77c4 the `datasource-classname` option was renamed to `datasource-class-name`. Using the old keyword would result in a silent failure. This patch turns it into an exception.