### PR TITLE
Correct property translation for MysqlConnector tinyInt1isBit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Added support for Mysql Connector's tinyInt1isBit property.
+
 ## 2.5.0
 
 * updated `HikariCP` to `3.2.0`

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ as a datasource property, unless a special translation is defined:
 
 ;; {:use-ssl false} has a custom translation, so it will be:
 (.addDataSourceProperty config "useSSL" false)
+
+;; {:tinyInt1isBit false} also has a custom translation to support the incorrect property casing in the original java class.
 ```
 
 Custom translations of properties can be added by extending the

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -134,6 +134,8 @@
                :jdbc-url ::jdbc-url-options)))
 
 (defmulti translate-property keyword)
+(defmethod translate-property :tinyInt1isBit [_] "tinyInt1isBit")
+(defmethod translate-property :tiny-int1is-bit [_] "tinyInt1isBit")
 (defmethod translate-property :use-ssl [_] "useSSL")
 (defmethod translate-property :useSSL [_] "useSSL")
 (defmethod translate-property :default [x] (mixed-name x))

--- a/test/hikari_cp/core_test.clj
+++ b/test/hikari_cp/core_test.clj
@@ -219,6 +219,8 @@
 (expect HikariPool$PoolInitializationException
   (make-datasource valid-options))
 
+(expect "tinyInt1isBit" (translate-property :tinyInt1isBit))
+(expect "tinyInt1isBit" (translate-property :tiny-int1is-bit))
 (expect "useSSL" (translate-property :useSSL))
 (expect "useSSL" (translate-property :use-ssl))
 (expect "useFoo" (translate-property :useFOO))


### PR DESCRIPTION
This is one way #77 could be solved. 