### PR TITLE
Add missing ::jdbc-url-options specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Add missing ::jdbc-url-options specs
+
 ## 2.6.0
 
 * Added support for Mysql Connector's tinyInt1isBit property.

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -122,6 +122,12 @@
 (s/def ::adapter-options
   (s/keys :req-un [::adapter]))
 
+(s/def ::jdbc-url
+  string?)
+
+(s/def ::driver-class-name
+  string?)
+
 (s/def ::jdbc-url-options
   (s/keys :req-un [::jdbc-url]
           :opt-un [::driver-class-name]))

--- a/test/hikari_cp/core_test.clj
+++ b/test/hikari_cp/core_test.clj
@@ -174,6 +174,11 @@
         (validate-options (merge valid-options {:adapter :foo})))
 (expect IllegalArgumentException
         (validate-options (merge valid-options {:datasource-classname "adsf"})))
+(expect IllegalArgumentException
+        (validate-options (merge (dissoc valid-options :adapter) {:jdbc-url nil})))
+(expect IllegalArgumentException
+        (validate-options (merge (dissoc valid-options :adapter) {:jdbc-url "jdbc:h2:~/test"
+                                                                  :driver-class-name nil})))
 (expect map?
         (validate-options (merge valid-options {:username nil})))
 (expect map?
@@ -194,6 +199,11 @@
         (validate-options (merge valid-options {:port-number -1})))
 (expect map?
         (validate-options (dissoc valid-options :port-number)))
+(expect map?
+        (validate-options (merge (dissoc valid-options :adapter) {:jdbc-url "jdbc:h2:~/test"})))
+(expect map?
+        (validate-options (merge (dissoc valid-options :adapter) {:jdbc-url "jdbc:h2:~/test"
+                                                                  :driver-class-name "org.h2.Driver"})))
 
 
 ;; -- check leak detections option


### PR DESCRIPTION
I was playing around with https://gist.github.com/stuarthalloway/f4c4297d344651c99827769e1c3d34e9 and I happened to notice that the `::jdbc-url` and `::driver-class-name` specs were missing.

I think they both need to be strings, correct?

Also, I have [Expound](https://github.com/bhb/expound) set as my spec explainer and I noticed that [one unit test fails](https://github.com/tomekw/hikari-cp/blob/e5be3d0e944868455e3e32c75d8b2a03202ffa2f/test/hikari_cp/core_test.clj#L142) because it expects a certain string in the output, but it doesn't occur with Expound. Probably not a huge deal, but just thought I'd mention it.