### PR TITLE
fixes tiny reflection warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Dear Contributors,
 When submitting patches please make sure to:
 
  - write tests covering your changes,
- - verify that you changes turn your tests from failing to passing,
+ - verify that your changes turn your tests from failing to passing,
  - update the `CHANGELOG` by adding an entry to the _unreleased_ section, and
  - adjust the documentation in `README` if necessary.
  

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -164,7 +164,7 @@
     (if (s/valid? ::configuration-options merged)
       merged
       (throw (IllegalArgumentException.
-               (s/explain-str ::configuration-options merged))))))
+               ^String (s/explain-str ::configuration-options merged))))))
 
 (def ^:private core-options
   [:adapter


### PR DESCRIPTION
Fixes the following minor reflection warning,
```
Reflection warning, hikari_cp/core.clj:166:14 - call to java.lang.IllegalArgumentException ctor can't be resolved.
```