### PR TITLE
Fix sqlite datasource class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* fixed sqlite adapter datasource class name
+
 ## 3.0.0
 
 * updated `HikariCP` to `5.0.1`

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Custom translations of properties can be added by extending the
 | `postgresql`     | `org.postgresql.ds.PGSimpleDataSource`             | **Yes**               |
 | `fdbsql`         | `com.foundationdb.sql.jdbc.ds.FDBSimpleDataSource` | No                    |
 | `sybase`         | `com.sybase.jdbc4.jdbc.SybDataSource`              | Yes                   |
+| `sqlite`         | `org.sqlite.SQLiteDataSource`                      | No                    |
 
 ## Usage
 

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -33,7 +33,7 @@
    "postgresql"     "org.postgresql.ds.PGSimpleDataSource"
    "fdbsql"         "com.foundationdb.sql.jdbc.ds.FDBSimpleDataSource"
    "sybase"         "com.sybase.jdbc4.jdbc.SybDataSource"
-   "sqlite"         "org.sqlite.JDBC"})
+   "sqlite"         "org.sqlite.SQLiteDataSource"})
 
 (defn- gte-0?
   "Returns true if num is greater than or equal 0, else false"


### PR DESCRIPTION
The class name was set to the driver class name instead of the datasource one.

Also added `sqlite` to the adapter list in the readme.