### PR TITLE
Add is-closed? and is-running? functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Custom translations of properties can be added by extending the
 ```clojure
 (ns hikari-cp.example
   (:require [hikari-cp.core :refer :all]
-            [clojure.java.jdbc :as jdbc]))
+            [next.jdbc :as jdbc]))
 
 (def datasource-options {:auto-commit        true
                          :read-only          false
@@ -124,7 +124,7 @@ Custom translations of properties can be added by extending the
   (delay (make-datasource datasource-options)))
 
 (defn -main [& args]
-  (jdbc/with-db-connection [conn {:datasource @datasource}]
+  (with-open [conn (jdbc/get-connection @datasource {})]
     (let [rows (jdbc/query conn "SELECT 0")]
       (println rows)))
   (close-datasource @datasource))
@@ -134,7 +134,7 @@ Custom translations of properties can be added by extending the
 ```clojure
 (ns hikari-cp.example
   (:require [hikari-cp.core :refer :all]
-            [clojure.java.jdbc :as jdbc]))
+            [next.jdbc :as jdbc]))
 
 (def datasource-options {:jdbc-url "jdbc:neo4j:bolt://host:port/?username=neo4j&password=xxxx&debug=true"})
 
@@ -142,7 +142,7 @@ Custom translations of properties can be added by extending the
   (delay (make-datasource datasource-options)))
 
 (defn -main [& args]
-  (jdbc/with-db-connection [conn {:datasource @datasource}]
+  (with-open [conn (jdbc/get-connection @datasource {})]
     (let [rows (jdbc/query conn ["MATCH (n:Foo) WHERE n.name = ? RETURN n" "john"])]
       (println rows)))
   (close-datasource @datasource))
@@ -159,7 +159,7 @@ Custom translations of properties can be added by extending the
 ```clojure
 (ns hikari-cp.example
   (:require [hikari-cp.core :refer :all]
-            [clojure.java.jdbc :as jdbc]))
+            [next.jdbc :as jdbc]))
 
 (def datasource-options {:username      "username"
                          :password      "password"
@@ -173,7 +173,7 @@ Custom translations of properties can be added by extending the
   (delay (make-datasource datasource-options)))
 
 (defn -main [& args]
-  (jdbc/with-db-connection [conn {:datasource @datasource}]
+  (with-open [conn (jdbc/get-connection @datasource {})]
     (let [rows (jdbc/query conn "SELECT 0 FROM dual")]
       (println rows)))
   (close-datasource @datasource))
@@ -184,7 +184,7 @@ Custom translations of properties can be added by extending the
 ```clojure
 (ns hikari-cp.example
   (:require [hikari-cp.core :refer :all]
-            [clojure.java.jdbc :as jdbc]))
+            [next.jdbc :as jdbc]))
 
 (def datasource-options {:username      "username"
                          :password      "password"
@@ -202,7 +202,7 @@ Custom translations of properties can be added by extending the
   (delay (make-datasource datasource-options)))
 
 (defn -main [& args]
-  (jdbc/with-db-connection [conn {:datasource @datasource}]
+  (with-open [conn (jdbc/get-connection @datasource {})]
     (let [rows (jdbc/query conn "SELECT 0")]
       (println rows)))
   (close-datasource @datasource))
@@ -245,12 +245,12 @@ Custom translations of properties can be added by extending the
    :max-lifetime 300000
    :pool-name "clickhouse-conn-pool"})
 
-(defonce datasource 
+(defonce datasource
   (delay (make-datasource datasource-options)))
 
 (defn -main
   [& args]
-  (with-open [conn (jdbc/get-connection {:datasource @datasource})]
+  (with-open [conn (jdbc/get-connection @datasource {})]
     (let [rows (jdbc/execute! conn ["SELECT 0"])]
       (println rows)))
   (close-datasource @datasource))
@@ -277,7 +277,7 @@ Custom translations of properties can be added by extending the
 
 (defn -main
   [& args]
-  (with-open [conn (jdbc/get-connection {:datasource @datasource})]
+  (with-open [conn (jdbc/get-connection @datasource {})]
     (let [rows (jdbc/execute! conn ["SELECT 0"])]
       (println rows)))
   (close-datasource @datasource))

--- a/project.clj
+++ b/project.clj
@@ -7,17 +7,19 @@
         :url  "https://github.com/tomekw/hikari-cp"}
   :dependencies [[org.clojure/clojure "1.11.1" :scope "provided"]
                  [org.tobereplaced/lettercase "1.0.0"]
-                 [com.zaxxer/HikariCP "5.0.1"]]
+                 [com.zaxxer/HikariCP "5.1.0"]]
+  :global-vars {*warn-on-reflection* true}
   :deploy-repositories [["clojars" {:sign-releases false :url "https://clojars.org/repo"}]]
   :profiles {:dev {:dependencies [[expectations "2.1.10"]
-                                  [org.slf4j/slf4j-nop "1.7.36"]
-                                  [org.clojure/java.jdbc "0.7.12"]
-                                  [mysql/mysql-connector-java "8.0.30"]
-                                  [org.neo4j.driver/neo4j-java-driver "5.0.0"]
-                                  [org.postgresql/postgresql "42.5.0"]
-                                  [io.dropwizard.metrics/metrics-core "4.2.12"]
-                                  [io.dropwizard.metrics/metrics-healthchecks "4.2.12"]
+                                  [org.slf4j/slf4j-nop "2.0.9"]
+                                  [com.github.seancorfield/next.jdbc "1.3.894"]
+                                  [mysql/mysql-connector-java "8.0.33"]
+                                  [org.neo4j.driver/neo4j-java-driver "5.15.0"]
+                                  [org.postgresql/postgresql "42.7.0"]
+                                  [io.dropwizard.metrics/metrics-core "4.2.22"]
+                                  [io.dropwizard.metrics/metrics-healthchecks "4.2.22"]
                                   [io.prometheus/simpleclient "0.16.0"]
+                                  [com.h2database/h2 "2.2.224"]
 
                                   ; The Oracle driver is only accessible from maven.oracle.com
                                   ; which requires a userId and password

--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -194,7 +194,7 @@
 
 (defn datasource-config
   "Create datasource config from `datasource-options`"
-  [datasource-options]
+  ^HikariConfig [datasource-options]
   (let [config (HikariConfig.)
         options               (validate-options datasource-options)
         not-core-options      (apply dissoc options core-options)
@@ -273,3 +273,13 @@
   "Close given `datasource`"
   [^HikariDataSource datasource]
   (.close datasource))
+
+(defn is-running?
+  "Check if given `datasource` is running"
+  [^HikariDataSource datasource]
+  (.isRunning datasource))
+
+(defn is-closed?
+  "Check if given `datasource` is closed"
+  [^HikariDataSource datasource]
+  (.isClosed datasource))

--- a/test/hikari_cp/connection_test.clj
+++ b/test/hikari_cp/connection_test.clj
@@ -1,0 +1,32 @@
+(ns hikari-cp.connection-test
+  (:require
+   [expectations :refer [expect]]
+   [hikari-cp.core :as hikari-cp]
+   [next.jdbc :as jdbc]))
+
+(let [pool (hikari-cp/make-datasource {:adapter "h2"
+                                       :url "jdbc:h2:mem:test"
+                                       ;; :register-mbeans true
+                                       ;; :connection-timeout 1000
+                                       ;; :connection-test-query "select 0"
+                                       })]
+
+  (with-open [connection (jdbc/get-connection pool {})]
+    (let [result (jdbc/execute-one! connection ["select 1 as count"])]
+      (expect {:COUNT 1} result)))
+
+  ;; NOTE:
+  ;; can't do this: (expect true (hikari-cp/is-running? pool))
+  ;; most likely due to how expectations works
+  (let [running? (hikari-cp/is-running? pool)
+        closed? (hikari-cp/is-closed? pool)]
+    (expect true running?)
+    (expect false closed?))
+
+  (hikari-cp/close-datasource pool)
+
+  (let [running? (hikari-cp/is-running? pool)
+        closed? (hikari-cp/is-closed? pool)]
+
+    (expect false running?)
+    (expect true closed?)))


### PR DESCRIPTION
This is useful to check the state of the connection pool when it's wrapped in a Component (or similar) to avoid issues when trying to close a pool that's already been closed but its instance is still around.


Plus a bunch of improvements:

- Closes #97
- A proper connection test with H2
- Updated documentation to use `next.jdbc`

Lastly, I'd be more than happy to rewrite all tests to use `clojure.test` - It's probably the first time I'm seeing `expectations` and run into weird issues with it, for example:

```clojure
;; this works:
  (let [running? (hikari-cp/is-running? pool)
        closed? (hikari-cp/is-closed? pool)]
    (expect true running?)
    (expect false closed?))

;; but this doesn't (always returns false!)

(expect true(hikari-cp/is-running? pool))
```
