### PR TITLE
Add keepalive-time as an option

### DIFF
--- a/src/hikari_cp/core.clj
+++ b/src/hikari_cp/core.clj
@@ -51,6 +51,11 @@
   [x]
   (>= x 1000))
 
+(defn- gte-30000?
+  "Returns true if num is greater than or equal 30000, else false"
+  [x]
+  (>= x 30000))
+
 (defn- leak-threshold?
   "Returns true only if x is acceptable value, 0 or greater-than-equal 2000"
   [x]
@@ -73,6 +78,9 @@
 
 (s/def ::validation-timeout
   (s/and integer? gte-1000?))
+
+(s/def ::keepalive-time
+  (s/and integer? gte-30000?))
 
 (s/def ::idle-timeout
   (s/and integer? gte-0?))
@@ -107,6 +115,7 @@
                           ::validation-timeout]
                  :opt-un [::allow-pool-suspension
                           ::connection-timeout
+                          ::keepalive-time
                           ::transaction-isolation
                           ::leak-detection-threshold])
          ;; Make sure that if the user provides the class
@@ -198,6 +207,7 @@
    :health-check-registry
    :idle-timeout
    :jdbc-url
+   :keepalive-time
    :leak-detection-threshold
    :max-lifetime
    :maximum-pool-size
@@ -228,6 +238,7 @@
                 connection-timeout
                 validation-timeout
                 idle-timeout
+                keepalive-time
                 max-lifetime
                 maximum-pool-size
                 minimum-idle
@@ -255,6 +266,7 @@
       (.setMaxLifetime         max-lifetime)
       (.setMinimumIdle         minimum-idle)
       (.setMaximumPoolSize     maximum-pool-size))
+    (when keepalive-time (.setKeepaliveTime config keepalive-time))
     (when datasource (.setDataSource config datasource))
     (if adapter
       (->> (get adapters-to-datasource-class-names adapter)

--- a/test/hikari_cp/core_test.clj
+++ b/test/hikari_cp/core_test.clj
@@ -353,6 +353,22 @@
     (is (thrown? IllegalArgumentException
                  (validate-options (assoc valid-options :leak-detection-threshold 1999))))))
 
+(deftest keepalive-time-test
+  (testing "default keepalive time is 120000 (2 minutes)"
+    (is (= 120000 (.getKeepaliveTime ^HikariConfig (datasource-config valid-options)))))
+
+  (testing "keepalive time can be set to valid value"
+    (let [config (datasource-config (assoc valid-options :keepalive-time 30000))]
+      (is (= 30000 (.getKeepaliveTime ^HikariConfig config)))))
+
+  (testing "keepalive time below 30000 throws exception"
+    (is (thrown? IllegalArgumentException
+                 (validate-options (assoc valid-options :keepalive-time 29999)))))
+
+  (testing "invalid keepalive time type throws exception"
+    (is (thrown? IllegalArgumentException
+                 (validate-options (assoc valid-options :keepalive-time "foo"))))))
+
 (deftest core-options-not-set-as-datasource-properties-test
   (testing "only non-core options are set as datasource properties"
     (is (= #{"portNumber" "databaseName" "serverName"}


### PR DESCRIPTION
Allow users to set `keepaliveTime` via the wrapper.